### PR TITLE
Render `.select2-selection__clear` before the inline content of `.sel…

### DIFF
--- a/src/scss/_single.scss
+++ b/src/scss/_single.scss
@@ -18,6 +18,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .select2-selection__clear {
+    position: relative;
+  }
 }
 
 &[dir="rtl"] {


### PR DESCRIPTION
…ect2-selection__rendered`.

As suggested by @njakobsen in https://github.com/select2/select2/issues/3306#issuecomment-109372777, this uses `position: relative` to alter the stacking level of `.select2-selection__clear`.
See http://www.w3.org/TR/CSS2/zindex.html#painting-order and https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/Stacking_without_z-index.

Styles are added to the default Sass for `.select2-selection--single`.
Does not include the recompiled distribution CSS.

References https://github.com/select2/select2/issues/3306.
Tested in Google Chrome v43.0.2357.130 only.
